### PR TITLE
Swapped the thousands separator and fraction separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ import VueCurrencyFilter from 'vue-currency-filter'
 import Vue from 'vue'
 Vue.use(VueCurrencyFilter, {
   symbol: '$',
-  thousandsSeparator: '.',
+  thousandsSeparator: ',',
   fractionCount: 2,
-  fractionSeparator: ',',
+  fractionSeparator: '.',
   symbolPosition: 'front',
   symbolSpacing: true
 })


### PR DESCRIPTION
Since the example shows a dollar, I swapped the thousands separator and fraction separator to match what a dollar format should look like.